### PR TITLE
fix: use Node module resolution for server build

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -2,13 +2,13 @@
   "compilerOptions": {
     "outDir": "./dist",
     "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "Node",
     "target": "ES2022",
     "skipLibCheck": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "types": [],
+    "types": ["node"],
     "baseUrl": ".",
     "paths": {
       "@shared/*": ["../shared/*"]


### PR DESCRIPTION
## Summary
- use Node module resolution in `server/tsconfig.json`
- include Node type definitions for server build

## Testing
- `npx tsc -p server/tsconfig.json` *(fails: type errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_68b919f014348326ae2779b49b4e5d77